### PR TITLE
Implement prefix-aware IRIs

### DIFF
--- a/src/test/scala/XmlToRdfTest.scala
+++ b/src/test/scala/XmlToRdfTest.scala
@@ -3,10 +3,13 @@
 import cats.effect.unsafe.implicits.global
 
 class XmlToRdfTest extends munit.FunSuite {
-  test("IRIs expanded in rdf:about") {
+  test("IRIs expanded and prefix declared") {
     XmlToRdf.run.unsafeRunSync()
     val rdf = scala.io.Source.fromFile("example.rdf").mkString
     assert(rdf.contains("rdf:about=\"http://example.org/"))
+    assert(rdf.contains("rdf:resource=\"http://example.org/"))
+    assert(rdf.contains("xmlns:ex=\"http://example.org/\""))
     assert(!rdf.contains("rdf:about=\"ex:"))
+    assert(!rdf.contains("rdf:resource=\"ex:"))
   }
 }


### PR DESCRIPTION
## Summary
- refactor `XmlToRdf` to use a prefix map
- add `expandPrefix` helper
- generate RDF header from declared prefixes
- update test to ensure prefix declaration and IRI expansion

## Testing
- `./tools/sbt-launch/bin/sbt test`

------
https://chatgpt.com/codex/tasks/task_e_685ef8e5ce108327958e75505d758cd4