### PR TITLE
Add provenance metadata to lifted RDF

### DIFF
--- a/src/main/scala/XmlToRdf.scala
+++ b/src/main/scala/XmlToRdf.scala
@@ -18,6 +18,7 @@ object XmlToRdf extends IOApp.Simple {
     "rdfs" -> "http://www.w3.org/2000/01/rdf-schema#",
     "owl"  -> "http://www.w3.org/2002/07/owl#",
     "ex"   -> "http://example.org/",
+    "prov" -> "http://www.w3.org/ns/prov#",
     "xsd" -> "http://www.w3.org/2001/XMLSchema#"
 
   )
@@ -139,12 +140,15 @@ object XmlToRdf extends IOApp.Simple {
       lang: Option[String],
       path: java.nio.file.Path
   ): XmlEvent => Stream[IO, String] = {
-    val tagSet = mutable.Set[String]() 
+    val tagSet = mutable.Set[String]()
     val tagToStrings = mutable.Map[String, mutable.Set[String]]().withDefault(_ => mutable.Set())
 
     var stack: List[(String, String)]    = Nil
     var emittedClasses: Set[String]      = Set.empty
     var emittedSemantic: Set[String]     = Set.empty
+    // event counter used as approximate source line number
+    var lineCounter: Int                 = 0
+    val liftedBy: String                 = java.util.UUID.randomUUID().toString
     val tagCounter: scala.collection.mutable.Map[String, Int] =
       scala.collection.mutable.Map.empty.withDefaultValue(0)
     val fileName = path.getFileName.toString
@@ -226,8 +230,18 @@ object XmlToRdf extends IOApp.Simple {
             Some(s"  <$prop rdf:datatype=\"$dt\">${escapeXml(attrVal)}</$prop>")
         }.flatten
 
+        lineCounter += 1
+        val xmlPath   = "/" + (stack.map(_._2).reverse :+ tag).mkString("/")
+        val provenanceLines = List(
+          s"  <prov:wasDerivedFrom rdf:resource=\"$fileUri\"/>",
+          s"  <ex:sourceLine rdf:datatype=\"${expandPrefix("xsd:integer")}\">$lineCounter</ex:sourceLine>",
+          s"  <ex:sourceXmlPath rdf:datatype=\"${expandPrefix("xsd:string")}\">${escapeXml(xmlPath)}</ex:sourceXmlPath>",
+          s"  <ex:liftedBy rdf:datatype=\"${expandPrefix("xsd:string")}\">$liftedBy</ex:liftedBy>"
+        )
+
         val subjectBlock =
           (List(s"<rdf:Description rdf:about=\"$subjectIRI\">", s"  <rdf:type rdf:resource=\"$synClassIRI\"/>") ++
+            provenanceLines ++
             attrLines ++
             List("</rdf:Description>")).mkString("\n")
 
@@ -241,7 +255,7 @@ object XmlToRdf extends IOApp.Simple {
             tagToStrings(tag) += text.trim
             if semanticEnabled then
               val valueIRI  = createSemanticIRI(text.trim)
-              val classIRI  = semanticClassIRI(_, tag)
+              val classIRI  = semanticClassIRI(None, tag)
               val hasProp   = createHasProperty(tag)
               val parentIRI = stack.drop(1).headOption.map(_._1)
 
@@ -252,8 +266,20 @@ object XmlToRdf extends IOApp.Simple {
               val valueBlock =
                 if !emittedSemantic.contains(valueIRI) then
                   emittedSemantic += valueIRI
+                  lineCounter += 1
+                  val xmlPathValue = "/" + stack.map(_._2).reverse.mkString("/") + "/text()"
+                  val valueProvenance = List(
+                    s"  <prov:wasDerivedFrom rdf:resource=\"$fileUri\"/>",
+                    s"  <ex:sourceLine rdf:datatype=\"${expandPrefix("xsd:integer")}\">$lineCounter</ex:sourceLine>",
+                    s"  <ex:sourceXmlPath rdf:datatype=\"${expandPrefix("xsd:string")}\">${escapeXml(xmlPathValue)}</ex:sourceXmlPath>",
+                    s"  <ex:liftedBy rdf:datatype=\"${expandPrefix("xsd:string")}\">$liftedBy</ex:liftedBy>"
+                  )
                   Some(
-                    s"<rdf:Description rdf:about=\"$valueIRI\">\n  <rdf:type rdf:resource=\"$classIRI\"/>\n  <rdfs:label xml:lang=\"${lang.getOrElse("en")}\">${escapeXml(text.trim)}</rdfs:label>\n</rdf:Description>"
+                    (
+                      List(s"<rdf:Description rdf:about=\"$valueIRI\">", s"  <rdf:type rdf:resource=\"$classIRI\"/>", s"  <rdfs:label xml:lang=\"${lang.getOrElse("en")}\">${escapeXml(text.trim)}</rdfs:label") ++
+                        valueProvenance ++
+                        List("</rdf:Description>")
+                    ).mkString("\n")
                   )
                 else None
 


### PR DESCRIPTION
## Summary
- attach provenance data to every emitted RDF description
- track approximate source lines and XML paths
- annotate semantic value nodes with derivation info
- register `prov` namespace for provenance links

## Testing
- `sbt compile`
- `sbt test` *(fails: XmlToRdfTest.dual individuals emitted)*

------
https://chatgpt.com/codex/tasks/task_e_686192db96488327a42f70f6404980c4