### PR TITLE
Implement LexiconAgent type inference

### DIFF
--- a/src/main/scala/LexiconAgent.scala
+++ b/src/main/scala/LexiconAgent.scala
@@ -1,0 +1,13 @@
+object LexiconAgent {
+  /** Infer basic XSD datatype for a string.
+    * Defaults to `xsd:string` when no lexical match is found.
+    */
+  def inferLiteralType(text: String): String =
+    text.trim match {
+      case s if s.matches("^-?\\d+$")       => "xsd:integer"
+      case s if s.matches("^-?\\d+\\.\\d+$") => "xsd:decimal"
+      case s if s.matches("^(true|false)$")  => "xsd:boolean"
+      case s if s.matches("\\d{4}-\\d{2}-\\d{2}") => "xsd:date"
+      case _                                 => "xsd:string"
+    }
+}

--- a/src/main/scala/XmlToRdf.scala
+++ b/src/main/scala/XmlToRdf.scala
@@ -9,6 +9,7 @@ import scala.util.hashing.MurmurHash3
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import LexiconAgent.*
 
 object XmlToRdf extends IOApp.Simple {
 
@@ -117,12 +118,8 @@ object XmlToRdf extends IOApp.Simple {
   def stringRole(tag: String): Option[String] =
     stringRoleMap.collectFirst { case (role, tags) if tags.contains(tag) => role }
 
-  def inferLiteralType(text: String): String = text.trim match { 
-    case s if s.matches("""^-?\d+\.\d+$""") => "xsd:decimal"
-    case s if s.matches("""^-?\d+$""")      => "xsd:integer"
-    case s if s.matches("""\d{4}-\d{2}-\d{2}""") => "xsd:date"
-    case _                                  => "xsd:string"
-  }
+  def inferLiteralType(text: String): String =
+    LexiconAgent.inferLiteralType(text)
 
   val rolesDir = Paths.get("roles")
   val tagRoleDir = rolesDir.resolve("TagRoles")

--- a/src/test/scala/XmlToRdfTest.scala
+++ b/src/test/scala/XmlToRdfTest.scala
@@ -16,15 +16,19 @@ class XmlToRdfTest extends munit.FunSuite {
   test("syntactic nodes emitted") {
     XmlToRdf.run.unsafeRunSync()
     val rdf = scala.io.Source.fromFile("example.rdf").mkString
-      }
+    assert(rdf.contains("ex:attribute rdf:resource"))
+    assert(rdf.contains("ex:xmlString rdf:datatype"))
+  }
 
   test("rdf can be lowered back to xml") {
     XmlToRdf.run.unsafeRunSync()
     RdfToXml.run(Nil).unsafeRunSync()
+    val rdf = scala.io.Source.fromFile("example.rdf").mkString
     val xml = scala.io.Source.fromFile("lowered.xml").mkString
     assert(rdf.contains("rdf:type rdf:resource=\"http://example.org/xmlTag\""))
     assert(rdf.contains("rdf:type rdf:resource=\"http://example.org/xmlAttribute\""))
     assert(rdf.contains("ex:attribute rdf:resource"))
     assert(rdf.contains("ex:xmlString rdf:datatype"))
+    assert(xml.nonEmpty)
   }
 }


### PR DESCRIPTION
## Summary
- add `LexiconAgent` to centralize datatype inference
- use new agent in `XmlToRdf`
- fix failing `XmlToRdfTest`

## Testing
- `sbt test` *(fails: Tests unsuccessful)*

------
https://chatgpt.com/codex/tasks/task_e_6861d7d98cec8327814a3b47dd28b703